### PR TITLE
fix: prod bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A few QoL improvement for the guessthe.game website",
   "scripts": {
     "dev": "plasmo dev",
-    "build": "plasmo build --minify --source-maps",
+    "build": "plasmo build",
     "package": "plasmo package"
   },
   "keywords": [
@@ -33,7 +33,7 @@
     "@plasmohq/storage": "^1.6.0",
     "autoprefixer": "^10.4.14",
     "fastdom": "^1.0.11",
-    "plasmo": "^0.70.1",
+    "plasmo": "^0.71.0",
     "postcss": "^8.4.23",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "A few QoL improvement for the guessthe.game website",
   "scripts": {
     "dev": "plasmo dev",
-    "build": "plasmo build",
+    "build": "plasmo build --hoist",
     "package": "plasmo package"
   },
   "keywords": [

--- a/popup.tsx
+++ b/popup.tsx
@@ -5,7 +5,7 @@ import {
   useOptions,
 } from "~source/helpers/options";
 
-import "./source/index.pcss";
+import "~source/popup.pcss";
 
 export default function Popup() {
   return (

--- a/source/popup.pcss
+++ b/source/popup.pcss
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
@HugeLetters The new version now ships with a better optimizer. Together with the `--hoist` flag and the fix included, your prod bundle should be functional.

Note: This PR was made before I pushed 0.71.0 - if npm doesn't update the version yet, pls check back later :p